### PR TITLE
[light] Improve constant brightness handling for CWWW

### DIFF
--- a/esphome/components/light/light_color_values.h
+++ b/esphome/components/light/light_color_values.h
@@ -182,19 +182,12 @@ class LightColorValues {
       *warm_white = white_level * ww_level;
       if (constant_brightness && (cw_level > 0 || ww_level > 0)) {
         const float sum = cw_level + ww_level;
-        *cold_white /= sum;
-        *warm_white /= sum;
-        // Just multiplying by cw_level / (cw_level + ww_level) would divide out the brightness information from the
-        // cold_white and warm_white settings (i.e. cw=0.8, ww=0.4 would be identical to cw=0.4, ww=0.2), which breaks
-        // transitions. Use the highest value as the brightness for the white channels (the alternative, using cw+ww/2,
-        // reduces to cw/2 and ww/2, which would still limit brightness to 100% of a single channel, but isn't very
-        // useful in all other aspects -- that behaviour can also be achieved by limiting the output power).
-        // const float sum = cw_level > 0 || ww_level > 0 ? cw_level + ww_level : 1;  // Don't divide by zero.
-        // *cold_white = white_level * std::max(cw_level, ww_level) * cw_level / sum;
-        // *warm_white = white_level * std::max(cw_level, ww_level) * ww_level / sum;
-      } else {
-        *cold_white = white_level * cw_level;
-        *warm_white = white_level * ww_level;
+        if (sum > 1.0f) {
+          // Limit total brightness to the highest channel while preserving the
+          // relative brightness of cold and warm white.
+          *cold_white = white_level * std::max(cw_level, ww_level) * cw_level / sum;
+          *warm_white = white_level * std::max(cw_level, ww_level) * ww_level / sum;
+        }
       }
     } else {
       *cold_white = *warm_white = 0;


### PR DESCRIPTION
## Summary
- fix constant brightness algorithm for cwww light

## Testing
- `pre-commit run --files esphome/components/light/light_color_values.h`
- `script/unit_test`

------
https://chatgpt.com/codex/tasks/task_b_687cd04c552c8333b3f954cdd15fdb7e