### PR TITLE
Fix constant brightness for CWWW lights

### DIFF
--- a/esphome/components/light/light_color_values.h
+++ b/esphome/components/light/light_color_values.h
@@ -180,21 +180,10 @@ class LightColorValues {
 
       *cold_white = white_level * cw_level;
       *warm_white = white_level * ww_level;
-      if (constant_brightness && (cw_level > 0 || ww_level > 0)) {
+      if (constant_brightness && (cw_level + ww_level > 1.0f)) {
         const float sum = cw_level + ww_level;
         *cold_white /= sum;
         *warm_white /= sum;
-        // Just multiplying by cw_level / (cw_level + ww_level) would divide out the brightness information from the
-        // cold_white and warm_white settings (i.e. cw=0.8, ww=0.4 would be identical to cw=0.4, ww=0.2), which breaks
-        // transitions. Use the highest value as the brightness for the white channels (the alternative, using cw+ww/2,
-        // reduces to cw/2 and ww/2, which would still limit brightness to 100% of a single channel, but isn't very
-        // useful in all other aspects -- that behaviour can also be achieved by limiting the output power).
-        // const float sum = cw_level > 0 || ww_level > 0 ? cw_level + ww_level : 1;  // Don't divide by zero.
-        // *cold_white = white_level * std::max(cw_level, ww_level) * cw_level / sum;
-        // *warm_white = white_level * std::max(cw_level, ww_level) * ww_level / sum;
-      } else {
-        *cold_white = white_level * cw_level;
-        *warm_white = white_level * ww_level;
       }
     } else {
       *cold_white = *warm_white = 0;


### PR DESCRIPTION
## Summary
- fix calculation when `constant_brightness` is enabled for CWWW/RGBWW lights
- keep brightness info unless sum exceeds max

## Testing
- `script/quicklint`
- `script/unit_test`
- `script/integration_test` *(fails to capture full output but ended with 5 passed)*

------
https://chatgpt.com/codex/tasks/task_b_687cd04c552c8333b3f954cdd15fdb7e